### PR TITLE
A few fixes for image links.

### DIFF
--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -428,6 +428,7 @@ button {
 
     &:hover {
       border: 2px solid darken($nsf-yellow, 10%);
+      box-decoration-break: clone;
       background: darken($nsf-yellow, 10%);
       text-decoration: none;
       margin: 0 -2px;
@@ -452,8 +453,13 @@ button {
       }
 
       &:hover span {
+        box-decoration-break: clone;
         border: 2px solid darken($nsf-yellow, 10%);
         background: darken($nsf-yellow, 10%);
+      }
+
+      &:focus {
+        outline: none;
       }
 
       div {
@@ -463,7 +469,11 @@ button {
           border-bottom: 2px solid $nsf-yellow;
           font-weight: 500;
           color: #000;
-          font-size: 20px;
+          font-size: 1rem;
+
+          @media screen and (min-width: $bp-md) {
+            font-size: 1.25rem;
+          }
         }
       }
     }


### PR DESCRIPTION
This fixes a few small things.

When the screen size gets small, the image links line break, and looks kinda bad.

Right click, open in new window, creates a terrible dotted line around the link.

If the lines still happen to line break, we need to make sure the border happens on the line break too, this is why I added the `box-decoration-break: clone;`